### PR TITLE
README.md: Added ruby explicitly to the "apt-get install" command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple debian packaging for Apache Karaf
 
 ```sh
 $ sudo apt-get update
-$ sudo apt-get install ruby-dev build-essential
+$ sudo apt-get install ruby ruby-dev build-essential
 $ sudo gem install fpm
 ```
 # Options


### PR DESCRIPTION
ruby-dev didn't pull in ruby as a dependency on debian
jessie, so there was no "gem" command.